### PR TITLE
[WIP] Support Github Actions

### DIFF
--- a/lib/codecov.rb
+++ b/lib/codecov.rb
@@ -230,6 +230,14 @@ class SimpleCov::Formatter::Codecov
       params[:branch] = ENV['HEROKU_TEST_RUN_BRANCH']
       params[:build] = ENV['HEROKU_TEST_RUN_ID']
       params[:commit] = ENV['HEROKU_TEST_RUN_COMMIT_VERSION']
+    # GitHub Actions
+    # ---------
+    elsif ENV['GITHUB_WORKFLOW']
+      # FIXME: Change to the corresponding name when GH Actions is supported
+      # params[:service] = 'github_actions_'
+      params[:service] = 'heroku'
+      params[:build] = ENV['_GITHUB_BUILD']
+      params[:commit] = ENV['GITHUB_SHA']
     end
 
     if params[:branch] == nil

--- a/test/test_codecov.rb
+++ b/test/test_codecov.rb
@@ -121,6 +121,9 @@ class TestCodecov < Minitest::Test
     ENV['ghprbSourceBranch'] = nil
     ENV['GIT_BRANCH'] = nil
     ENV['GIT_COMMIT'] = nil
+    ENV['GITHUB_SHA'] = nil
+    ENV['GITHUB_WORKFLOW'] = nil
+    ENV['_GITHUB_BUILD'] = nil
     ENV['GITLAB_CI'] = nil
     ENV['HEROKU_TEST_RUN_ID'] = nil
     ENV['HEROKU_TEST_RUN_BRANCH'] = nil
@@ -442,6 +445,21 @@ class TestCodecov < Minitest::Test
     assert_equal("master", result['params'][:branch])
     assert_equal('f881216b-b5c0-4eb1-8f21-b51887d1d506', result['params']['token'])
   end
+  def test_github_actions
+    ENV['GITHUB_SHA'] = '743b04806ea677403aa2ff26c6bdeb85005de658'
+    ENV['GITHUB_WORKFLOW'] = "codecov"
+    ENV['_GITHUB_BUILD'] = "123"
+    ENV['CODECOV_TOKEN'] = 'f881216b-b5c0-4eb1-8f21-b51887d1d506'
+
+    result = upload
+
+    # assert_equal("github_actions", result['params'][:service])
+    assert_equal("heroku", result['params'][:service])
+    assert_equal("123", result['params'][:build])
+    assert_equal("743b04806ea677403aa2ff26c6bdeb85005de658", result['params'][:commit])
+    assert_equal('f881216b-b5c0-4eb1-8f21-b51887d1d506', result['params']['token'])
+  end
+
   def test_bitbucket_pr
     ENV['CI'] = 'true'
     ENV['BITBUCKET_BUILD_NUMBER'] = "100"


### PR DESCRIPTION
This PR adds support for GitHub Actions.

All environment variables are described in the page below.

https://help.github.com/en/articles/virtual-environments-for-github-actions

It seems that there are some other variables to detect if CodeCov runs on GitHub Actions.  I chose `GITHUB_WORKFLOW` because it should not be empty according to the help page.

```
The name of your workflow. GitHub displays the names of your workflows on your repository's actions page. If you omit this field, GitHub sets the name to the workflow's filename.
```

https://help.github.com/en/articles/workflow-syntax-for-github-actions#name

I couldn't find a environment variable to assign `params[:build]`. 